### PR TITLE
Per-defense auto program parameters

### DIFF
--- a/CompetitionTemplate/src/competition/operator_interface/OperatorCommandMap.java
+++ b/CompetitionTemplate/src/competition/operator_interface/OperatorCommandMap.java
@@ -15,7 +15,9 @@ import competition.subsystems.autonomous.DriveForDistanceCommand;
 import competition.subsystems.autonomous.LowBarScoreCommandGroup;
 import competition.subsystems.autonomous.TurnToHeadingCommand;
 import competition.subsystems.autonomous.selection.DisableAutonomousCommand;
+import competition.subsystems.autonomous.selection.SetupLowBarCommand;
 import competition.subsystems.autonomous.selection.SetupRaiseArmAndTraverseCommand;
+import competition.subsystems.autonomous.selection.SetupRoughDefenseCommand;
 import competition.subsystems.autonomous.selection.SetupTraverseDefenseCommand;
 import competition.subsystems.drive.PoseSubsystem;
 import competition.subsystems.drive.commands.CalibrateHeadingCommand;
@@ -153,7 +155,8 @@ public class OperatorCommandMap {
             TurnToHeadingCommand turnToHeading,
             SetupTraverseDefenseCommand setupTraverseDefenseCommand,
             DisableAutonomousCommand disableAutonomousCommand,
-            SetupRaiseArmAndTraverseCommand setupRaiseAndTraverse){
+            SetupLowBarCommand setupLowBarCommand,
+            SetupRoughDefenseCommand setupRoughDefenseCommand){
         driveToTurningPoint.setTargetDistance(lowBarScoreGroup.distanceToTurningPoint.get());
         driveToTurningPoint.includeOnSmartDashboard();
         
@@ -163,9 +166,12 @@ public class OperatorCommandMap {
         driveToLowGoal.setTargetDistance(lowBarScoreGroup.distanceToLowGoal.get());
         driveToLowGoal.includeOnSmartDashboard();
         
+        // TODO: remove this entry once we've tested the fancier ones below 
         setupTraverseDefenseCommand.includeOnSmartDashboard();
+        
         disableAutonomousCommand.includeOnSmartDashboard();
-        setupRaiseAndTraverse.includeOnSmartDashboard();
+        setupLowBarCommand.includeOnSmartDashboard();
+        setupRoughDefenseCommand.includeOnSmartDashboard();
     }
     
     @Inject

--- a/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupLowBarCommand.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupLowBarCommand.java
@@ -1,0 +1,19 @@
+package competition.subsystems.autonomous.selection;
+
+import xbot.common.properties.XPropertyManager;
+
+import com.google.inject.Inject;
+
+import competition.subsystems.autonomous.RaiseArmAndTraverseDefenseCommandGroup;
+
+
+public class SetupLowBarCommand extends SetupRaiseArmAndTraverseCommand {
+    
+    final String label = "LowBarAuto ";
+    
+    @Inject
+    public SetupLowBarCommand(XPropertyManager propMan, RaiseArmAndTraverseDefenseCommandGroup auto,
+            AutonomousModeSelector autonomousModeSelector) {
+        super(propMan, auto, autonomousModeSelector);
+    }
+}

--- a/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupRaiseArmAndTraverseCommand.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupRaiseArmAndTraverseCommand.java
@@ -1,6 +1,5 @@
 package competition.subsystems.autonomous.selection;
 
-import xbot.common.command.BaseCommand;
 import xbot.common.properties.DoubleProperty;
 import xbot.common.properties.XPropertyManager;
 
@@ -8,10 +7,9 @@ import com.google.inject.Inject;
 
 import competition.subsystems.autonomous.RaiseArmAndTraverseDefenseCommandGroup;
 import competition.subsystems.drive.PoseSubsystem;
-import competition.subsystems.drive.commands.TraverseDefenseCommand;
 
 
-public class SetupRaiseArmAndTraverseCommand extends BaseAutonomousModeSetCommand {
+public abstract class SetupRaiseArmAndTraverseCommand extends BaseAutonomousModeSetCommand {
 
     RaiseArmAndTraverseDefenseCommandGroup auto;
     
@@ -22,18 +20,20 @@ public class SetupRaiseArmAndTraverseCommand extends BaseAutonomousModeSetComman
     final DoubleProperty traverseMaxTime;
     final DoubleProperty initialAutoHeading;
     
+    final String label = "";
+    
     @Inject
     public SetupRaiseArmAndTraverseCommand(XPropertyManager propMan, 
             RaiseArmAndTraverseDefenseCommandGroup auto,
             AutonomousModeSelector autonomousModeSelector) {
         super(autonomousModeSelector);
         
-        traverseDefenseHeading = propMan.createPersistentProperty("traverseDefenseHeading", 90.0);
-        traverseDefensePower = propMan.createPersistentProperty("traverseDefensePower", 0.75);
-        autoArmGoal = propMan.createPersistentProperty("autonomousArmGoal", 30.0);
-        traverseMinTime = propMan.createPersistentProperty("traverseDefenseMinTime", 1.0);
-        traverseMaxTime = propMan.createPersistentProperty("traverseDefenseMaxTime", 3.0);
-        initialAutoHeading = propMan.createPersistentProperty("initialAutoHeading", PoseSubsystem.FACING_AWAY_FROM_DRIVERS);
+        traverseDefenseHeading = propMan.createPersistentProperty(label + "traverseDefenseHeading", 90.0);
+        traverseDefensePower = propMan.createPersistentProperty(label + "traverseDefensePower", 0.75);
+        autoArmGoal = propMan.createPersistentProperty(label + "autonomousArmGoal", 30.0);
+        traverseMinTime = propMan.createPersistentProperty(label + "traverseDefenseMinTime", 1.0);
+        traverseMaxTime = propMan.createPersistentProperty(label + "traverseDefenseMaxTime", 3.0);
+        initialAutoHeading = propMan.createPersistentProperty(label + "initialAutoHeading", PoseSubsystem.FACING_AWAY_FROM_DRIVERS);
         
         this.auto = auto;
     }

--- a/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupRoughDefenseCommand.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupRoughDefenseCommand.java
@@ -1,0 +1,19 @@
+package competition.subsystems.autonomous.selection;
+
+import xbot.common.properties.XPropertyManager;
+
+import com.google.inject.Inject;
+
+import competition.subsystems.autonomous.RaiseArmAndTraverseDefenseCommandGroup;
+
+
+public class SetupRoughDefenseCommand extends SetupRaiseArmAndTraverseCommand {
+    
+    final String label = "RoughDefenseAuto ";
+    
+    @Inject
+    public SetupRoughDefenseCommand(XPropertyManager propMan, RaiseArmAndTraverseDefenseCommandGroup auto,
+            AutonomousModeSelector autonomousModeSelector) {
+        super(propMan, auto, autonomousModeSelector);
+    }
+}

--- a/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupTraverseDefenseCommand.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/selection/SetupTraverseDefenseCommand.java
@@ -22,10 +22,10 @@ public class SetupTraverseDefenseCommand extends BaseAutonomousModeSetCommand {
     public SetupTraverseDefenseCommand(XPropertyManager propMan, 
             TraverseDefenseCommand traverseDefenseCommand, AutonomousModeSelector autonomousModeSelector) {
         super(autonomousModeSelector);
-        traverseDefenseHeading = propMan.createPersistentProperty("traverseDefenseHeading", 90.0);
-        traverseDefensePower = propMan.createPersistentProperty("traverseDefensePower", 0.75);
+        traverseDefenseHeading = propMan.createPersistentProperty("traverseDefenseHeading", -90.0);
+        traverseDefensePower = propMan.createPersistentProperty("traverseDefensePower", -0.90);
         traverseMinTime = propMan.createPersistentProperty("traverseMinTime", 1.5);
-        traverseMaxTime = propMan.createPersistentProperty("traverseMaxTime", 3.5);
+        traverseMaxTime = propMan.createPersistentProperty("traverseMaxTime", 4);
         
         this.traverseDefenseCommand = traverseDefenseCommand;
     }


### PR DESCRIPTION
Would like to make it really easy to add a bunch of copies of the smart traverse command per defense type. Idea here is to add a string prefix to the properties so they each get their own copy. One downside is that they all default to the same base class values but I wasn't sure if it was worth plumbing that through given we'll need to tune them anyway.
@JohnGilb 