### PR TITLE
Feature/drive after traverse

### DIFF
--- a/CompetitionTemplate/src/competition/subsystems/autonomous/RaiseArmAndTraverseDefenseCommandGroup.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/RaiseArmAndTraverseDefenseCommandGroup.java
@@ -49,6 +49,7 @@ public class RaiseArmAndTraverseDefenseCommandGroup extends CommandGroup{
         this.addSequential(waitForArmCalibration);
         this.addSequential(this.setArm);
         this.addSequential(this.traverse);
+        // TODO: have this timeout be in the command itself vs part of the sequencing. Then we could use it for move first as well
         this.addSequential(this.moveToClearDefense, this.moveToClearDefenseDuration.get());
     }
     
@@ -62,6 +63,7 @@ public class RaiseArmAndTraverseDefenseCommandGroup extends CommandGroup{
         
         moveToClearDefense.setTargetHeading(heading);
         
+        // Have the moving power match the sign of the tarversal power but be generally lower
         double moveFirstPower = 0.4;
         if (power < 0) {
             moveFirstPower *= -1;

--- a/CompetitionTemplate/src/competition/subsystems/autonomous/RaiseArmAndTraverseDefenseCommandGroup.java
+++ b/CompetitionTemplate/src/competition/subsystems/autonomous/RaiseArmAndTraverseDefenseCommandGroup.java
@@ -6,6 +6,7 @@ import competition.subsystems.arm.arm_commands.ArmAngleMaintainerCommand;
 import competition.subsystems.arm.arm_commands.SetArmToAngleCommand;
 import competition.subsystems.arm.arm_commands.WaitForArmCalibrationCommand;
 import competition.subsystems.drive.commands.CalibrateHeadingCommand;
+import competition.subsystems.drive.commands.HeadingDriveCommand;
 import competition.subsystems.drive.commands.TraverseDefenseCommand;
 import edu.wpi.first.wpilibj.command.CommandGroup;
 import xbot.common.properties.DoubleProperty;
@@ -17,8 +18,10 @@ public class RaiseArmAndTraverseDefenseCommandGroup extends CommandGroup{
     TraverseDefenseCommand traverse;
     SetArmToAngleCommand setArm;
     CalibrateHeadingCommand calibrateHeading;
+    HeadingDriveCommand moveToClearDefense;
     
     DoubleProperty moveFirstDuration;
+    DoubleProperty moveToClearDefenseDuration;
     
     public String label;
     
@@ -29,20 +32,24 @@ public class RaiseArmAndTraverseDefenseCommandGroup extends CommandGroup{
             SetArmToAngleCommand setArm,
             TraverseDefenseCommand traverse,
             CalibrateHeadingCommand calibrateHeading,
+            HeadingDriveCommand moveToClearDefense,
             XPropertyManager propMan) {
         
         this.traverse = traverse;
         this.setArm = setArm;
         this.calibrateHeading = calibrateHeading;
         this.moveFirst = moveFirst;
+        this.moveToClearDefense = moveToClearDefense;
         
         moveFirstDuration = propMan.createPersistentProperty("MoveFirstDuration", 0.75);
+        moveToClearDefenseDuration = propMan.createPersistentProperty("RaiseArmAndTraverse MoveToClearDuration", 0.5);
         
         this.addSequential(this.calibrateHeading);
         this.addSequential(moveFirst);
         this.addSequential(waitForArmCalibration);
         this.addSequential(this.setArm);
         this.addSequential(this.traverse);
+        this.addSequential(this.moveToClearDefense, this.moveToClearDefenseDuration.get());
     }
     
     public void setTraversalProperties(double power, double heading, double minSeconds, double maxSeconds) {
@@ -53,12 +60,15 @@ public class RaiseArmAndTraverseDefenseCommandGroup extends CommandGroup{
         moveFirst.setTargetHeading(heading);
         moveFirst.setTimeLimits(moveFirstDuration.get(), moveFirstDuration.get() + 0.05);
         
+        moveToClearDefense.setTargetHeading(heading);
+        
         double moveFirstPower = 0.4;
         if (power < 0) {
             moveFirstPower *= -1;
         }
         
         moveFirst.setPower(moveFirstPower);
+        moveToClearDefense.setPower(moveFirstPower);
     }
     
     public void setArmAngle(double goalAngle) {


### PR DESCRIPTION
Right now the traversal command is tuned to stop once it gets flat again, but right now that still leaves the bumper within the defense and we don't count as crossed. This adds a command to the group to roll a little bit at the end.

@JohnGilb